### PR TITLE
chore: プロジェクトバージョンをv2025.07.09に更新

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "shopee-product-filter"
-version = "0.1.0"
-description = "Add your description here"
+version = "v2025.07.09"
+description = "HTMLからShopeeの商品情報を抽出し、データベースで管理、APIとStreamlit UIで操作・分析するシステム。"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [


### PR DESCRIPTION
pyproject.tomlのプロジェクトバージョンをv2025.07.09に更新しました。
これは、カレンダーバージョニング（CalVer）スキームを採用したものです。