### PR TITLE
feat: Streamlitアプリのページネーション関連UI/変数名を改善 (#14)

### DIFF
--- a/src/shopee_product_filter/app/product_list_streamlit_app_type1.py
+++ b/src/shopee_product_filter/app/product_list_streamlit_app_type1.py
@@ -409,10 +409,12 @@ with st.form(key="product_list_search_form_with_sourcing"):  # キー名を変�
         default=DEFAULT_PRODUCT_LIST_DISPLAY_COLUMNS,
         key="pl_display_cols_s",
     )
-    offset = st.number_input(
-        "表示開始位置 (オフセット)", min_value=0, value=0, step=20, key="pl_offset_s"
+    # ページネーションのための表示開始位置
+    display_start_index = st.number_input(
+        "表示開始位置 (ページネーション用)", min_value=0, value=0, step=20, key="pl_offset_s"
     )
-    limit = st.number_input(
+    # ページネーションのための最大表示件数
+    display_limit = st.number_input(
         "最大表示件数 (リミット)",
         min_value=1,
         max_value=200,
@@ -428,7 +430,7 @@ if "searched_product_list_df" not in st.session_state:
     st.session_state.searched_product_list_df = pd.DataFrame()
 
 if search_and_update_button:
-    search_params: Dict[str, Any] = {"offset": offset, "limit": limit}
+    search_params: Dict[str, Any] = {"offset": display_start_index, "limit": display_limit}
     # (中略 - 価格、販売数などのパラメータ組み立ては前回と同じ)
     if display_rate_sgd_jpy:
         if price_jpy_min is not None:

--- a/src/shopee_product_filter/app/product_list_streamlit_app_type2.py
+++ b/src/shopee_product_filter/app/product_list_streamlit_app_type2.py
@@ -168,8 +168,9 @@ with st.form(key="product_list_search_form"):
     selected_columns_to_display = st.multiselect(
         "検索結果テーブル表示項目:", options=ALL_PRODUCT_LIST_COLUMNS, default=DEFAULT_PRODUCT_LIST_DISPLAY_COLUMNS, key="pl_display_cols"
     )
-    offset_pl = st.number_input("表示開始位置 (オフセット)", min_value=0, value=0, step=10, key="pl_offset")
-    limit_pl = st.number_input("最大表示件数 (リミット)", min_value=1, max_value=200, value=50, step=10, key="pl_limit")
+    # ページネーションのための表示開始位置
+    display_start_index = st.number_input("表示開始位置 (ページネーション用)", min_value=0, value=0, step=10, key="pl_offset")
+    display_limit = st.number_input("最大表示件数 (リミット)", min_value=1, max_value=200, value=50, step=10, key="pl_limit")
     search_button = st.form_submit_button(label="この条件で検索")
 
 if search_button:
@@ -184,11 +185,11 @@ if search_button:
         "start_date_input (form)": start_date_val.isoformat() if start_date_val else None,
         "end_date_input (form)": end_date_val.isoformat() if end_date_val else None,
         "selected_columns_to_display": selected_columns_to_display,
-        "offset": offset_pl, "limit": limit_pl
+        "offset": display_start_index, "limit": display_limit
     }
     logger.info(f"検索フォーム入力値: {form_inputs}")
 
-    search_params_api: Dict[str, Any] = {"offset": offset_pl, "limit": limit_pl}
+    search_params_api: Dict[str, Any] = {"offset": display_start_index, "limit": display_limit}
     min_price_sgd_val: Optional[float] = None
     max_price_sgd_val: Optional[float] = None
     if st.session_state.jpy_to_sgd_rate:


### PR DESCRIPTION
Streamlitアプリケーション (`product_list_streamlit_app_type1.py` および `product_list_streamlit_app_type2.py`) において、データ表示のオフセットに関するUIと変数名を、ページネーションの文脈がより明確になるように改善する。

**変更内容:**
*   `st.number_input` のラベルを「表示開始位置 (オフセット)」から「表示開始位置 (ページネーション用)」に変更する。
*   `offset` または `offset_pl` といった変数名を、`display_start_index` のように、より意図が明確になる名前に変更する。
*   `limit` または `limit_pl` といった変数名を、`display_limit` のように、より意図が明確になる名前に変更する。
*   関連する計算ロジックが正しく機能し続けることを確認する。

**対象ファイル:**
*   `src/shopee_product_filter/app/product_list_streamlit_app_type1.py`
*   `src/shopee_product_filter/app/product_list_streamlit_app_type2.py`

Closes #14